### PR TITLE
Changed navigation from <a> tags to <Link> components

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { SocialLinks } from '../components/social/SocialLinks';
 import { motion } from 'framer-motion';
 
@@ -140,14 +141,13 @@ export function Home() {
         >
           Visit my Tech-Blog
         </motion.a>        
-        <motion.a
-          href="/portfolio"
+        <motion.div
           className="inline-block px-6 py-3 bg-white text-blue-900 rounded-full font-semibold hover:bg-blue-100 transition-colors cursor-glow"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >
-          Check out my Portfolio
-        </motion.a>
+          <Link to="/portfolio">Check out my Portfolio</Link>
+        </motion.div>
       </footer>
     </div>
   );


### PR DESCRIPTION
### Description
This PR fixes the 404 error on the Portfolio page.

## Changes:
- HashRouter adaptation was already implemented
- changed `<a>` tag to `<Link>` components provided by `react-router-dom` in `Home.tsx`
  - `<a>` tag trigger a normal browser page transition,  causing a full page reload without involving React Router
  - However, for internal navigation within the same application, page transitions should be handled by `<Link>` component or the `useNavigate` hook provided by React Router
  - for external links pointing to different services, using `<a>` tag is appropriate as they provide standard browser behavior for external navigation

fixed #5